### PR TITLE
fixed: crash when clicking the 'Use Video' button

### DIFF
--- a/ios-7-programming-cookbook-source-codes-master/Chapter 15/Taking Videos with the Camera/Taking Videos with the Camera/ViewController.m
+++ b/ios-7-programming-cookbook-source-codes-master/Chapter 15/Taking Videos with the Camera/Taking Videos with the Camera/ViewController.m
@@ -70,7 +70,7 @@
     
     if ([mediaType isEqualToString:(__bridge NSString *)kUTTypeMovie]){
         
-        NSURL *urlOfVideo = info[UIImagePickerControllerMediaType];
+        NSURL *urlOfVideo = info[UIImagePickerControllerMediaURL];
         
         NSLog(@"Video URL = %@", urlOfVideo);
         


### PR DESCRIPTION
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFConstantString isFileURL]: unrecognized selector sent to instance
